### PR TITLE
Changed target-entity of UserRegistration->user from Implemation to Interface

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -19,6 +19,13 @@ return array(
                     'HtUserRegistration\Entity' => 'HtUserRegistration\Entity'
                 )
             )
-        )
+        ),
+        'entity_resolver' => array(
+            'orm_default' => array(
+                'resolvers' => array(
+                    'ZfcUser\Entity\UserInterface' => 'ZfcUser\Entity\User',
+                )
+            )
+        ),
     ),
 );

--- a/config/xml/HtUserRegistration/HtUserRegistration.Entity.UserRegistration.dcm.xml
+++ b/config/xml/HtUserRegistration/HtUserRegistration.Entity.UserRegistration.dcm.xml
@@ -6,7 +6,7 @@
 
     <mapped-superclass name="HtUserRegistration\Entity\UserRegistration" table="user_registration">
         <id name="user" association-key="true"></id>
-        <one-to-one field="user" target-entity="ZfcUser\Entity\User">
+        <one-to-one field="user" target-entity="ZfcUser\Entity\UserInterface">
             <join-column name="user_id" referenced-column-name="user_id" on-delete="CASCADE"/>
         </one-to-one>
         <field name="token" length="16" type="string"></field>


### PR DESCRIPTION
Hi,
i encountered a problem whlie trying do create a bi-directional accociation pointing from my user-class to \HtUserRegistrationDoctrineORM\Entity\UserRegistration.

That was the property in my UserClass:

``` php
    /**
     * 
     * @ORM\OneToOne(targetEntity="\HtUserRegistrationDoctrineORM\Entity\UserRegistration", mappedBy="user")
     * @var \HtUserRegistration\Entity\UserRegistrationInterface
     */
    protected $mailVerification;
```

However, doctrine refused to work with this configuration, since your were pointing to ZfcUser\Entity\User

``` xml
<one-to-one field="user" target-entity="ZfcUser\Entity\User">
```

According to the post on stackoverflow i did some changes. http://stackoverflow.com/questions/17588682/doctrine-inheritance-replacement

Maybe you want to merge the changes.

Further enhancement would be having an Interface for Entity\UserRegistration.

Best
